### PR TITLE
reorder readme sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,17 @@
 
 **Hashcat** is an advanced CPU-based password recovery utility for Windows 7/8/10, Apple OS X, and GNU/Linux, supporting seven unique modes of attack for over 100 optimized hashing algorithms.
 
-### License ###
-
-**Hashcat** is licensed under the MIT license. Refer to [docs/license.txt](docs/license.txt) for more information. 
-
 ### Installation ###
 
 Download the [latest release](https://hashcat.net/hashcat/) and unpack it in the desired location. Please remember to use `7z x` when unpacking the archive from the command line to ensure full file paths remain intact.
 
-### Usage/Help ###
-
-Please refer to the [Hashcat Wiki](http://hashcat.net/wiki/) and the output of `--help` for usage information and general help. A list of frequently asked questions may also be found [here](http://hashcat.net/wiki/doku.php?id=frequently_asked_questions). The [Hashcat Forums](http://hashcat.net/forum/) also contain a plethora of information. 
-
-### Building ###
+### Building from source ###
 
 Refer to [docs/BUILD.md](docs/BUILD.md) for instructions on how to build **Hashcat** from source.
+
+### Usage/Help ###
+
+Please refer to the [Hashcat Wiki](http://hashcat.net/wiki/) and the output of `--help` for usage information and general help. A list of frequently asked questions may also be found [here](http://hashcat.net/wiki/doku.php?id=frequently_asked_questions). The [Hashcat Forums](http://hashcat.net/forum/) also contain a plethora of information.
 
 ### Contributing ###
 
@@ -25,9 +21,9 @@ Contributions are welcome and encouraged, provided your code is of sufficient qu
 1. Licensed under MIT license, or dedicated to public domain (BSD, GPL, etc. code is incompatible)
 2. Adheres to either C89, C90, or C99 standards
 2. Compiles cleanly with no warnings when compiled with `-W -Wall -std=c99`
-3. Uses [Allman-style](https://en.wikipedia.org/wiki/Indent_style#Allman_style) code blocks & indentation 
+3. Uses [Allman-style](https://en.wikipedia.org/wiki/Indent_style#Allman_style) code blocks & indentation
 4. Uses 2-character tabs and 2-character indentations
-5. Uses lower-case function and variable names 
+5. Uses lower-case function and variable names
 6. Avoids the use of `!` and uses positive conditionals wherever possible (e.g., `if (foo == 0)` instead of `if (!foo)`, and `if (foo)` instead of `if (foo !=0)`)
 
 You can use GNU Indent to help assist you with the style requirements:
@@ -43,5 +39,9 @@ Solve only one problem in each pull request. If you're fixing a bug and adding a
 If your patch fixes a bug, please be sure there is an [issue](https://github.com/hashcat/hashcat/issues) open for the bug before submitting a pull request. If your patch aims to improve performance or optimizes an algorithm, be sure to quantify your optimizations and document the trade-offs, and back up your claims with benchmarks and metrics.
 
 In order to maintain the quality and integrity of the **Hashcat** source tree, all pull requests must be reviewed and signed off by at least two [board members](https://github.com/orgs/hashcat/people) before being merged. The [project lead](https://github.com/jsteube) has the ultimate authority in deciding whether to accept or reject a pull request. Do not be discouraged if your pull request is rejected!
+
+### License ###
+
+**Hashcat** is licensed under the MIT license. Refer to [docs/license.txt](docs/license.txt) for more information.
 
 ### Happy Cracking!


### PR DESCRIPTION
Might make sense to get right down to installation first, then alternatively building from source, then usage/help.
