### PR TITLE
OSX: use sysctl to determine number of cpu(s)

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -10,6 +10,13 @@
 #define _FILE_OFFSET_BITS 64
 #define __MSVCRT_VERSION__ 0x0700
 
+#ifdef __APPLE__
+    #include <TargetConditionals.h>
+    #ifdef TARGET_OS_MAC
+			#define OSX
+    #endif
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>

--- a/include/common.h
+++ b/include/common.h
@@ -10,13 +10,6 @@
 #define _FILE_OFFSET_BITS 64
 #define __MSVCRT_VERSION__ 0x0700
 
-#ifdef __APPLE__
-    #include <TargetConditionals.h>
-    #ifdef TARGET_OS_MAC
-			#define OSX
-    #endif
-#endif
-
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ OS       := $(shell uname)
 ifeq ($(OS),Linux)
   NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 else ifeq ($(OS),Darwin)
-  NPROCS := $(shell system_profiler | awk '/Number of CPUs/ {print $$4}{next;}')
+  NPROCS := $(shell sysctl -n hw.ncpu)
 endif
 
 ##
@@ -68,7 +68,7 @@ release:
 ##
 
 DIR_OSX64      = obj
-CC_OSX64       = i686-apple-darwin10-gcc
+CC_OSX64       = llvm-gcc
 LIBGMP_OSX64   = /opt/hashcat-deps/gmp/osx64
 CFLAGS_OSX64   = $(CFLAGS) -I$(LIBGMP_OSX64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5
 LDFLAGS_OSX64  = $(LDFLAGS) -L$(LIBGMP_OSX64)/lib -lm -lpthread  -mmacosx-version-min=10.5 -lgmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ OS       := $(shell uname)
 ifeq ($(OS),Linux)
   NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 else ifeq ($(OS),Darwin)
-  NPROCS := $(shell system_profiler | awk '/Number of CPUs/ {print $$4}{next;}')
+  NPROCS := $(shell sysctl -n hw.ncpu)
 endif
 
 ##

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ OS       := $(shell uname)
 ifeq ($(OS),Linux)
   NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 else ifeq ($(OS),Darwin)
-  NPROCS := $(shell sysctl -n hw.ncpu)
+  NPROCS := $(shell system_profiler | awk '/Number of CPUs/ {print $$4}{next;}')
 endif
 
 ##
@@ -68,7 +68,7 @@ release:
 ##
 
 DIR_OSX64      = obj
-CC_OSX64       = llvm-gcc
+CC_OSX64       = i686-apple-darwin10-gcc
 LIBGMP_OSX64   = /opt/hashcat-deps/gmp/osx64
 CFLAGS_OSX64   = $(CFLAGS) -I$(LIBGMP_OSX64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5
 LDFLAGS_OSX64  = $(LDFLAGS) -L$(LIBGMP_OSX64)/lib -lm -lpthread  -mmacosx-version-min=10.5 -lgmp


### PR DESCRIPTION
`system_profiler` is untolerably slow; `sysctl` is fast and is BSD compatible. We shall use it. BTW, what do you mean by "Number of CPUs" ? Number of CPU(s), number of physical cores, or number of logical  core(s)?
