### PR TITLE
should fix issue #10: possible memory problem for hash type -m 11400 (SIP Auth)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,3 +1,10 @@
+* changes v2.00 -> v2.01:
+
+type.: Feature
+file.: Host
+desc.: Fix a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
+issue: 10
+
 * changes v0.50 -> v2.00:
 
 type: Project

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -2,7 +2,7 @@
 
 type.: Feature
 file.: Host
-desc.: Fix a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
+desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
 issue: 10
 
 * changes v0.50 -> v2.00:

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -13159,9 +13159,16 @@ void load_hashes (FILE *fp, db_t *db, engine_parameter_t *engine_parameter)
 
           memset (&salt_search->additional_plain_struct[i].buf, 0, additional_plain_max_len);
 
-          snprintf (additional_plain_ptr, additional_plain_max_len + 1, "%s:%s:", user_pos, realm_pos);
+          int buf_len = snprintf (additional_plain_ptr, additional_plain_max_len, "%s:%s:", user_pos, realm_pos);
 
-          salt_search->additional_plain_struct[i].len = user_len + 1 + realm_len + 1;
+          int expected_buf_len = user_len + 1 + realm_len + 1;
+
+          if (buf_len != expected_buf_len) // this should never occur because buffer is large enough, but we better have a check anyway
+          {
+            log_warning ("username and realm (%d bytes) do not fit within the buffer (%d bytes)", expected_buf_len, buf_len);
+          }
+
+          salt_search->additional_plain_struct[i].len = buf_len;
         }
 
         salt_t *salt;


### PR DESCRIPTION
remove the +1 within the snprintf () but instead added a check and warning if there is a problem with memory size.

This is a fix for issue #10, warnings and related problem should be gone now.
