### PR TITLE
cosmetic fix for issue #13: sometimes tabs were used instead of 2 spaces

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -28,37 +28,37 @@ void log_msg (FILE *fp, const char *fmt, va_list ap)
 
 void log_info (const char *fmt, ...)
 {
-	va_list ap;
+  va_list ap;
 
-	va_start (ap, fmt);
+  va_start (ap, fmt);
 
   log_msg (stdout, fmt, ap);
 
-	va_end (ap);
+  va_end (ap);
 }
 
 void log_warning (const char *fmt, ...)
 {
-	va_list ap;
+  va_list ap;
 
-	va_start (ap, fmt);
+  va_start (ap, fmt);
 
   log_msg (stderr, fmt, ap);
 
-	va_end (ap);
+  va_end (ap);
 }
 
 void log_error (const char *fmt, ...)
 {
-	va_list ap;
+  va_list ap;
 
-	va_start (ap, fmt);
+  va_start (ap, fmt);
 
   fprintf (stderr, "\n\n");
 
   log_msg (stderr, fmt, ap);
 
-	va_end (ap);
+  va_end (ap);
 }
 
 uint32_t get_random_num (uint32_t min, uint32_t max)
@@ -147,11 +147,11 @@ void *myrealloc (void *ptr, size_t size)
 
 char *mystrdup (const char *s)
 {
-	char *b = mymalloc (strlen (s) + 1);
+  char *b = mymalloc (strlen (s) + 1);
 
-	strcpy (b, s);
+  strcpy (b, s);
 
-	return (b);
+  return (b);
 }
 
 int in_superchop (char *buf)

--- a/src/tsearch.c
+++ b/src/tsearch.c
@@ -128,15 +128,15 @@ void * __hc_tsearch (const void *key, void **vrootp, __hc_compar_fn_t compar)
 
   if (q != NULL)
   {
-    *nextp = q;			/* link new node to old */
-    q->key = key;			/* initialize new node */
+    *nextp = q;       /* link new node to old */
+    q->key = key;     /* initialize new node  */
     q->red = 1;
     q->left = q->right = NULL;
 
-	  /*
-     * There may be two red edges in a row now, which we must avoid by
-	   * rotating the tree.
-     */
+    /*
+    * There may be two red edges in a row now, which we must avoid by
+    * rotating the tree.
+    */
     if (nextp != rootp) hc_maybe_split_for_insert (nextp, rootp, parentp, r, p_r, 1);
   }
 

--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -9,8 +9,8 @@ GMP_VER="gmp-6.1.0"
 
 ## root check
 if [ $(id -u) -ne 0 ]; then
-	echo "! Must be root"
-	exit 1
+  echo "! Must be root"
+  exit 1
 fi
 
 ## make a fresh "hashcat-deps" directories
@@ -19,113 +19,113 @@ mkdir -p /opt/hashcat-deps/gmp/{linux32,linux64,win32,win64,osx64} /opt/hashcat-
 cd /opt/hashcat-deps/tmp
 
 if [ $? -ne 0 ]; then
-	echo "! Cannot create hashcat-deps directories."
-	exit 1
+  echo "! Cannot create hashcat-deps directories."
+  exit 1
 fi
 
 ## install osx cross stuff
 if [ ! -d "apple-pkgs" ]; then
-	mkdir -p apple-pkgs
+  mkdir -p apple-pkgs
 fi
 cd apple-pkgs
 
 if [ ! -f "libssl0.9.8_0.9.8o-4squeeze14_amd64.deb" ]; then
-	wget -c http://http.us.debian.org/debian/pool/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
-	if [ $? -ne 0 ]; then
-		echo "! failed to download libssl0.9.8 debian package"
-		exit 1
-	fi
+  wget -c http://http.us.debian.org/debian/pool/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
+  if [ $? -ne 0 ]; then
+    echo "! failed to download libssl0.9.8 debian package"
+    exit 1
+  fi
 fi
 
 dpkg -i libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
 if [ $? -ne 0 ]; then
-	echo "! failed to install libssl0.9.8"
-	exit 1
+  echo "! failed to install libssl0.9.8"
+  exit 1
 fi
 
 if [ ! -f "apple-uni-sdk-10.5_20110407-0.flosoft1_amd64.deb" ]; then
-	wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-uni-sdk-10.5_20110407-0.flosoft1_amd64.deb
-	if [ $? -ne 0 ]; then
-		echo "! failed to download apple-uni-sdk-10.5 debian package"
-		exit 1
-	fi
+  wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-uni-sdk-10.5_20110407-0.flosoft1_amd64.deb
+  if [ $? -ne 0 ]; then
+    echo "! failed to download apple-uni-sdk-10.5 debian package"
+    exit 1
+  fi
 fi
 
 dpkg -i apple-uni-sdk-10.5_20110407-0.flosoft1_amd64.deb
 if [ $? -ne 0 ]; then
-	echo "! failed to install apple-uni-sdk-10.5"
-	exit 1
+  echo "! failed to install apple-uni-sdk-10.5"
+  exit 1
 fi
 
 if [ ! -f "apple-uni-sdk-10.6_20110407-0.flosoft1_amd64.deb" ]; then
-	wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-uni-sdk-10.6_20110407-0.flosoft1_amd64.deb
-	if [ $? -ne 0 ]; then
-		echo "! failed to download apple-uni-sdk-10.6 debian package"
-		exit 1
-	fi
+  wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-uni-sdk-10.6_20110407-0.flosoft1_amd64.deb
+  if [ $? -ne 0 ]; then
+    echo "! failed to download apple-uni-sdk-10.6 debian package"
+    exit 1
+  fi
 fi
 
 dpkg -i apple-uni-sdk-10.6_20110407-0.flosoft1_amd64.deb
 if [ $? -ne 0 ]; then
-	echo "! failed to install apple-uni-sdk-10.6"
-	exit 1
+  echo "! failed to install apple-uni-sdk-10.6"
+  exit 1
 fi
 
 if [ ! -f "apple-x86-odcctools_758.159-0flosoft11_amd64.deb" ]; then
-	wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-x86-odcctools_758.159-0flosoft11_amd64.deb
-	if [ $? -ne 0 ]; then
-		echo "! failed to download apple-x86-odcctools debian package"
-		exit 1
-	fi
+  wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-x86-odcctools_758.159-0flosoft11_amd64.deb
+  if [ $? -ne 0 ]; then
+    echo "! failed to download apple-x86-odcctools debian package"
+    exit 1
+  fi
 fi
 
 dpkg -i apple-x86-odcctools_758.159-0flosoft11_amd64.deb
 if [ $? -ne 0 ]; then
-	echo "! failed to install apple-x86-odcctools"
-	exit 1
+  echo "! failed to install apple-x86-odcctools"
+  exit 1
 fi
 
 if [ ! -f "apple-x86-gcc_4.2.1~5646.1flosoft2_amd64.deb" ]; then
-	wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-x86-gcc_4.2.1~5646.1flosoft2_amd64.deb
-	if [ $? -ne 0 ]; then
-		echo "! failed to download apple-x86-gcc debian package"
-		exit 1
-	fi
+  wget -c https://launchpad.net/~flosoft/+archive/ubuntu/cross-apple/+files/apple-x86-gcc_4.2.1~5646.1flosoft2_amd64.deb
+  if [ $? -ne 0 ]; then
+    echo "! failed to download apple-x86-gcc debian package"
+    exit 1
+  fi
 fi
 
 dpkg -i apple-x86-gcc_4.2.1~5646.1flosoft2_amd64.deb
 if [ $? -ne 0 ]; then
-	echo "! failed to install apple-x86-gcc"
-	exit 1
+  echo "! failed to install apple-x86-gcc"
+  exit 1
 fi
 
 cd ..
 
 ## installing needed packages
 for pkg in ${DEPS}; do
-	apt-get -y install ${pkg}
-	if [ $? -ne 0 ]; then
-	    echo "! failed to install ${pkg}"
-	    exit 1
-	fi
+  apt-get -y install ${pkg}
+  if [ $? -ne 0 ]; then
+    echo "! failed to install ${pkg}"
+    exit 1
+  fi
 done
 
 ## download gmp source code
 wget -c https://gmplib.org/download/gmp/${GMP_VER}.tar.lz
 if [ $? -ne 0 ]; then
-	echo "! failed to download GMP source code"
-	exit 1
+  echo "! failed to download GMP source code"
+  exit 1
 fi
 
 tar xf ${GMP_VER}.tar.lz
 if [ $? -ne 0 ]; then
-	echo "! failed to extract GMP source code"
-	exit 1
+  echo "! failed to extract GMP source code"
+  exit 1
 fi
 
 newDir=$(tar tvf ${GMP_VER}.tar.lz | head -n1 | awk '{print $6}' | sed -e 's/\///g')
 if [ "${newDir}" != "${GMP_VER}" ]; then
-	mv ${newDir} ${GMP_VER}
+  mv ${newDir} ${GMP_VER}
 fi
 
 ## build gmp lib for linux32
@@ -137,8 +137,8 @@ cd .. && \
 rm -rf ${GMP_VER}-linux32
 
 if [ $? -ne 0 ]; then
-	echo "! failed to build linux32 gmp lib."
-	exit 1
+  echo "! failed to build linux32 gmp lib."
+  exit 1
 fi
 
 ## build gmp lib for linux64
@@ -150,8 +150,8 @@ cd .. && \
 rm -rf ${GMP_VER}-linux64
 
 if [ $? -ne 0 ]; then
-	echo "! failed to build linux64 gmp lib."
-	exit 1
+  echo "! failed to build linux64 gmp lib."
+  exit 1
 fi
 
 ## build gmp lib for win32
@@ -163,8 +163,8 @@ cd .. && \
 rm -rf ${GMP_VER}-win32
 
 if [ $? -ne 0 ]; then
-	echo "! failed to build win32 gmp lib."
-	exit 1
+  echo "! failed to build win32 gmp lib."
+  exit 1
 fi
 
 ## build gmp lib for win64
@@ -176,8 +176,8 @@ cd .. && \
 rm -rf ${GMP_VER}-win64
 
 if [ $? -ne 0 ]; then
-	echo "! failed to build win64 gmp lib."
-	exit 1
+  echo "! failed to build win64 gmp lib."
+  exit 1
 fi
 
 ## build gmp lib for osx64
@@ -190,8 +190,8 @@ cd .. && \
 rm -rf ${GMP_VER}-osx64
 
 if [ $? -ne 0 ]; then
-	echo "! failed to build osx64 gmp lib."
-	exit 1
+  echo "! failed to build osx64 gmp lib."
+  exit 1
 fi
 
 echo "> GMP library build success."


### PR DESCRIPTION
cosmetic fix: replace tabs with 2 spaces wherever possible in source code

According to the contribution/formating rule:
5. Uses 2-character tabs and 2-character indentations

... we should always prefer 2 spaces and not use tabs.

The main problem (besides that it was not accordance to the rules) is that github displays the tabs with 4 spaces and hence some code parts (mostly the indentations) looked horrible when looking at the source code on github.
This pull request does not affect any logic etc it is just a cosmetic fix (and everything seems to work as before).
Thx
