### PR TITLE
Add FreeBSD build target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,13 +30,14 @@ all: binaries
 clean:
 	rm -rf core out word hash release obj/* hashcat.pot hashcat-cli*
 
-binaries: linux windows osx
+binaries: linux windows osx 
 
 osx: osx64
 #linux: posix32 posix64 posixAVX posixAVX2 posixXOP
 #windows: windows32 windows64 windowsAVX windowsAVX2 windowsXOP
 linux: posix32 posix64 posixXOP
 windows: windows32 windows64 windowsXOP
+freebsd: freebsd64
 
 release:
 	rm -rf release
@@ -93,6 +94,48 @@ common-osx64: $(DIR_OSX64)/common.OSX.64.o
 
 $(DIR_OSX64)/common.OSX.64.o: src/common.c
 	$(CC_OSX64) $(CFLAGS_OSX64) -c src/common.c -o $(DIR_OSX64)/common.OSX.64.o
+
+##
+## FREEBSD
+##
+
+DIR_FREEBSD64      = obj
+CC_FREEBSD64       = clang
+CFLAGS_FREEBSD64   = $(CFLAGS) -I$(LIBGMP_FREEBSD64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions 
+LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/include -lgmp -lm -lpthread 
+
+freebsd64: hashcat-cli64.bin
+
+rules-freebsd64: rules-debug64.bin
+
+rules-debug64.bin: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.bin $(LDFLAGS_FREEBSD64)
+
+hashcat-freebsd64: hashcat-cli64.bin
+
+hashcat-cli64.bin: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.bin $(LDFLAGS_FREEBSD64)
+
+engine-freebsd64: $(DIR_FREEBSD64)/engine.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/engine.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/engine.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/engine.c -o $(DIR_FREEBSD64)/engine.FREEBSD.64.o
+
+rp-freebsd64: $(DIR_FREEBSD64)/rp.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/rp.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/rp.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/rp.c -o $(DIR_FREEBSD64)/rp.FREEBSD.64.o
+
+tsearch-freebsd64: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/tsearch.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/tsearch.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/tsearch.c -o $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o
+
+common-freebsd64: $(DIR_FREEBSD64)/common.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/common.FREEBSD.64.o: src/common.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/common.c -o $(DIR_FREEBSD64)/common.FREEBSD.64.o
+
 
 ##
 ## POSIX32

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,21 +100,21 @@ $(DIR_OSX64)/common.OSX.64.o: src/common.c
 ##
 
 DIR_FREEBSD64      = obj
-CC_FREEBSD64       = clang
-CFLAGS_FREEBSD64   = $(CFLAGS) -I$(LIBGMP_FREEBSD64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions 
-LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/include -lgmp -lm -lpthread 
+CC_FREEBSD64       = gcc
+CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 
+LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/lib -lgmp -lm -lpthread -lc
 
-freebsd64: hashcat-cli64.bin
+freebsd64: hashcat-cli64.elf
 
-rules-freebsd64: rules-debug64.bin
+rules-freebsd64: rules-debug64.elf
 
-rules-debug64.bin: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
-	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.bin $(LDFLAGS_FREEBSD64)
+rules-debug64.elf: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.elf $(LDFLAGS_FREEBSD64)
 
-hashcat-freebsd64: hashcat-cli64.bin
+hashcat-freebsd64: hashcat-cli64.elf
 
-hashcat-cli64.bin: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
-	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.bin $(LDFLAGS_FREEBSD64)
+hashcat-cli64.elf: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.elf $(LDFLAGS_FREEBSD64)
 
 engine-freebsd64: $(DIR_FREEBSD64)/engine.FREEBSD.64.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,10 +101,10 @@ $(DIR_OSX64)/common.OSX.64.o: src/common.c
 
 DIR_FREEBSD64      = obj
 CC_FREEBSD64       = gcc
-CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 
+CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2 
 LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/lib -lgmp -lm -lpthread -lc
 
-freebsd64: hashcat-cli64.elf
+freebsd64: hashcat-cli64.elf 
 
 rules-freebsd64: rules-debug64.elf
 

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -3,9 +3,15 @@
  * License.....: MIT
  */
 
+#ifdef FREEBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
 #ifdef OSX
 #include <sys/sysctl.h>
 #endif
+
 
 #define _FILE_OFFSET_BITS 64
 #define _CRT_SECURE_NO_WARNINGS
@@ -17,14 +23,14 @@
 
 // for interactive status prompt
 #ifdef POSIX
-#ifndef OSX
-
-#include <termio.h>
-
-#else
+#if defined(OSX) || defined(FREEBSD)
 
 #include <termios.h>
 #include <sys/ioctl.h>
+
+#else
+
+#include <termio.h>
 
 #endif
 #endif

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -12,7 +12,6 @@
 #include <sys/sysctl.h>
 #endif
 
-
 #define _FILE_OFFSET_BITS 64
 #define _CRT_SECURE_NO_WARNINGS
 
@@ -2842,7 +2841,7 @@ void save_hash ()
 
 #ifdef POSIX
 
-#ifndef OSX
+#if !defined(OSX) && !defined(FREEBSD)
 
 static struct termio savemodes;
 static int havemodes = 0;


### PR DESCRIPTION
# Overview

This PR is for a few small changes to enable hashcat to compile natively on FreeBSD systems so that us poor pentesters in the world who run FreeBSD on their testing machine can use it without relying on linux compatibility layers and such....

....yup both of us would be very grateful :)

The code didn't need changing at all; its just that the header files are in slightly different places. Given that OSX is a derivative of BSD, it wasn't much work just to add a target for it and fix up a few flags here and there.

I've kept it out of the binaries Makefile target because this isn't designed for cross-compiling; its for FreeBSD users to just clone the repo, type gmake and then use it!
# Testing

```
[stuart@freefall ~/github/hashcat]$ uname -mors 
FreeBSD 10.2-RELEASE amd64
[stuart@freefall ~/github/hashcat]$ gmake clean
rm -rf core out word hash release obj/* hashcat.pot hashcat-cli*
[stuart@freefall ~/github/hashcat]$ gmake freebsd
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/common.c -o obj/common.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/tsearch.c -o obj/tsearch.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/rp.c -o obj/rp.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/engine.c -o obj/engine.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2 obj/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.elf  -L/usr/local/lib -lgmp -lm -lpthread -lc
[stuart@freefall ~/github/hashcat]$ ./hashcat-cli64.elf --version
2.00
[stuart@freefall ~/github/hashcat]$ 
```
