### PR TITLE
add FreeBSD target to make it clear what works

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,6 +37,7 @@ osx: osx64
 #windows: windows32 windows64 windowsAVX windowsAVX2 windowsXOP
 linux: posix32 posix64 posixXOP
 windows: windows32 windows64 windowsXOP
+freebsd: posix64 posixAVX posixAVX2 posixXOP
 
 release:
 	rm -rf release


### PR DESCRIPTION
These are targets I tested and use in the upcoming FreeBSD port.
Before:
ALL_TARGET= posix64 posixAVX posixAVX2 posixXOP
After:
ALL_TARGET= freebsd
