### PR TITLE
Add freebsd build target

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -29,6 +29,13 @@ Run make depending on your os
 $ make [linux|osx|windows]
 ```
 
-Not specifying an argument will build for all OSes.
+Not specifying an argument will build for all OSes except FreeBSD.
+
+If you want FreeBSD binaries, you will need to run this on a native FreeBSD amd64 system
+```sh
+$ make freebsd
+```
+
+This has been tested on FreeBSD 10.2 and will produce **./hashcat-cli64.elf**. You will need **gmp** installed (/usr/ports/math/gmp).
 
 Enjoy your fresh **Hashcat** binaries ;)

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,13 +30,14 @@ all: binaries
 clean:
 	rm -rf core out word hash release obj/* hashcat.pot hashcat-cli*
 
-binaries: linux windows osx
+binaries: linux windows osx 
 
 osx: osx64
 #linux: posix32 posix64 posixAVX posixAVX2 posixXOP
 #windows: windows32 windows64 windowsAVX windowsAVX2 windowsXOP
 linux: posix32 posix64 posixXOP
 windows: windows32 windows64 windowsXOP
+freebsd: freebsd64
 
 release:
 	rm -rf release
@@ -93,6 +94,48 @@ common-osx64: $(DIR_OSX64)/common.OSX.64.o
 
 $(DIR_OSX64)/common.OSX.64.o: src/common.c
 	$(CC_OSX64) $(CFLAGS_OSX64) -c src/common.c -o $(DIR_OSX64)/common.OSX.64.o
+
+##
+## FREEBSD
+##
+
+DIR_FREEBSD64      = obj
+CC_FREEBSD64       = clang
+CFLAGS_FREEBSD64   = $(CFLAGS) -I$(LIBGMP_FREEBSD64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions 
+LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/include -lgmp -lm -lpthread 
+
+freebsd64: hashcat-cli64.bin
+
+rules-freebsd64: rules-debug64.bin
+
+rules-debug64.bin: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.bin $(LDFLAGS_FREEBSD64)
+
+hashcat-freebsd64: hashcat-cli64.bin
+
+hashcat-cli64.bin: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.bin $(LDFLAGS_FREEBSD64)
+
+engine-freebsd64: $(DIR_FREEBSD64)/engine.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/engine.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/engine.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/engine.c -o $(DIR_FREEBSD64)/engine.FREEBSD.64.o
+
+rp-freebsd64: $(DIR_FREEBSD64)/rp.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/rp.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/rp.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/rp.c -o $(DIR_FREEBSD64)/rp.FREEBSD.64.o
+
+tsearch-freebsd64: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/tsearch.FREEBSD.64.o: $(DIR_FREEBSD64)/common.FREEBSD.64.o src/tsearch.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/tsearch.c -o $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o
+
+common-freebsd64: $(DIR_FREEBSD64)/common.FREEBSD.64.o
+
+$(DIR_FREEBSD64)/common.FREEBSD.64.o: src/common.c
+	$(CC_FREEBSD64) $(CFLAGS_FREEBSD64) -c src/common.c -o $(DIR_FREEBSD64)/common.FREEBSD.64.o
+
 
 ##
 ## POSIX32

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,21 +100,21 @@ $(DIR_OSX64)/common.OSX.64.o: src/common.c
 ##
 
 DIR_FREEBSD64      = obj
-CC_FREEBSD64       = clang
-CFLAGS_FREEBSD64   = $(CFLAGS) -I$(LIBGMP_FREEBSD64)/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions 
-LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/include -lgmp -lm -lpthread 
+CC_FREEBSD64       = gcc
+CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 
+LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/lib -lgmp -lm -lpthread -lc
 
-freebsd64: hashcat-cli64.bin
+freebsd64: hashcat-cli64.elf
 
-rules-freebsd64: rules-debug64.bin
+rules-freebsd64: rules-debug64.elf
 
-rules-debug64.bin: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
-	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.bin $(LDFLAGS_FREEBSD64)
+rules-debug64.elf: $(DIR_FREEBSD64)/rp.FREEBSD.64.o src/rules-debug.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/rules-debug.c -o rules-debug64.elf $(LDFLAGS_FREEBSD64)
 
-hashcat-freebsd64: hashcat-cli64.bin
+hashcat-freebsd64: hashcat-cli64.elf
 
-hashcat-cli64.bin: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
-	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.bin $(LDFLAGS_FREEBSD64)
+hashcat-cli64.elf: $(DIR_FREEBSD64)/tsearch.FREEBSD.64.o $(DIR_FREEBSD64)/rp.FREEBSD.64.o $(DIR_FREEBSD64)/engine.FREEBSD.64.o src/hashcat-cli.c
+	$(CC_FREEBSD64) $(filter-out -s,$(CFLAGS_FREEBSD64)) $(DIR_FREEBSD64)/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.elf $(LDFLAGS_FREEBSD64)
 
 engine-freebsd64: $(DIR_FREEBSD64)/engine.FREEBSD.64.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,10 +101,10 @@ $(DIR_OSX64)/common.OSX.64.o: src/common.c
 
 DIR_FREEBSD64      = obj
 CC_FREEBSD64       = gcc
-CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 
+CFLAGS_FREEBSD64   = $(CFLAGS) -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2 
 LDFLAGS_FREEBSD64  = $(LDFLAGS) -L/usr/local/lib -lgmp -lm -lpthread -lc
 
-freebsd64: hashcat-cli64.elf
+freebsd64: hashcat-cli64.elf 
 
 rules-freebsd64: rules-debug64.elf
 

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -6,6 +6,7 @@
 #ifdef FREEBSD
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#include <sys/ttydefaults.h>
 #endif
 
 #ifdef OSX
@@ -2840,9 +2841,7 @@ void save_hash ()
 }
 
 #ifdef POSIX
-
-#if !defined(OSX) && !defined(FREEBSD)
->>>>>>> fd6bd8ccba6a646b729c8e60253c650bb0fc14b7
+#if !defined(OSX) 
 
 static struct termios savemodes;
 static int havemodes = 0;

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -2841,7 +2841,7 @@ void save_hash ()
 }
 
 #ifdef POSIX
-#if !defined(OSX) 
+#if defined(OSX) || defined(FREEBSD)
 
 static struct termios savemodes;
 static int havemodes = 0;

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -3,9 +3,15 @@
  * License.....: MIT
  */
 
+#ifdef FREEBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
 #ifdef OSX
 #include <sys/sysctl.h>
 #endif
+
 
 #define _FILE_OFFSET_BITS 64
 #define _CRT_SECURE_NO_WARNINGS
@@ -17,14 +23,14 @@
 
 // for interactive status prompt
 #ifdef POSIX
-#ifndef OSX
-
-#include <termio.h>
-
-#else
+#if defined(OSX) || defined(FREEBSD)
 
 #include <termios.h>
 #include <sys/ioctl.h>
+
+#else
+
+#include <termio.h>
 
 #endif
 #endif

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -12,7 +12,6 @@
 #include <sys/sysctl.h>
 #endif
 
-
 #define _FILE_OFFSET_BITS 64
 #define _CRT_SECURE_NO_WARNINGS
 
@@ -2842,7 +2841,7 @@ void save_hash ()
 
 #ifdef POSIX
 
-#ifndef OSX
+#if !defined(OSX) && !defined(FREEBSD)
 
 static struct termio savemodes;
 static int havemodes = 0;


### PR DESCRIPTION
See #20

I think there are multiple people working on this so I'm happy to go with the majority on this one :) I only did this because I'm a native FreeBSD user and couldn't get the original one going with what was there. Happy to close this or merge it in with another PR - whatever works really.

However, I've tested this on both FreeBSD and Linux and it seems to work. Evidence below:

**FreeBSD**

```
[stuart@freefall ~/github/hashcat]$ gmake clean
rm -rf core out word hash release obj/* hashcat.pot hashcat-cli*
[stuart@freefall ~/github/hashcat]$ ls
Makefile           build_freebsd.txt  deps/              examples/          makelog.txt        obj/               salts/             tables/
README.md          charsets/          docs/              include/           masks/             rules/             src/               tools/
[stuart@freefall ~/github/hashcat]$ gmake freebsd
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/common.c -o obj/common.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/tsearch.c -o obj/tsearch.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/rp.c -o obj/rp.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2  -c src/engine.c -o obj/engine.FREEBSD.64.o
gcc -W -Wall -pipe -I include/ -O2 -fomit-frame-pointer -funroll-loops -I/usr/local/include -DFREEBSD -DPOSIX -m64 -msse2 obj/*.FREEBSD.64.o src/hashcat-cli.c -o hashcat-cli64.elf  -L/usr/local/lib -lgmp -lm -lpthread -lc
[stuart@freefall ~/github/hashcat]$ ls   
Makefile           build_freebsd.txt  deps/              examples/          include/           masks/             rules/             src/               tools/
README.md          charsets/          docs/              hashcat-cli64.elf* makelog.txt        obj/               salts/             tables/
[stuart@freefall ~/github/hashcat]$ ./hashcat-cli64.elf --version
2.00
```

**Linux**

```
root@kali:~/hosthome/github/hashcat# make clean
rm -rf core out word hash release obj/* hashcat.pot hashcat-cli*
root@kali:~/hosthome/github/hashcat# make
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux32/include -D__HC_x86_32__ -DPOSIX -m32 -msse2 -c src/common.c -o obj/common.LINUX.32.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_x86_64__ -DPOSIX -m64 -msse2 -c src/common.c -o obj/common.LINUX.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_XOP__ -DPOSIX -m64 -mxop -c src/common.c -o obj/common.LINUX.XOP.o
i686-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win32/include -D__HC_x86_32__ -DWINDOWS -m32 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/common.c -o obj/common.WIN.32.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_x86_64__ -DWINDOWS -m64 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/common.c -o obj/common.WIN.64.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_XOP__ -DWINDOWS -m64 -mxop -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/common.c -o obj/common.WIN.XOP.o
i686-apple-darwin10-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/osx64/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5 -c src/common.c -o obj/common.OSX.64.o
i686-apple-darwin10-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/osx64/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5 -c src/tsearch.c -o obj/tsearch.OSX.64.o
i686-apple-darwin10-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/osx64/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5 -c src/rp.c -o obj/rp.OSX.64.o
i686-apple-darwin10-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/osx64/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5 -c src/engine.c -o obj/engine.OSX.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_XOP__ -DPOSIX -m64 -mxop -c src/tsearch.c -o obj/tsearch.LINUX.XOP.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_XOP__ -DPOSIX -m64 -mxop -c src/rp.c -o obj/rp.LINUX.XOP.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_XOP__ -DPOSIX -m64 -mxop -c src/engine.c -o obj/engine.LINUX.XOP.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux32/include -D__HC_x86_32__ -DPOSIX -m32 -msse2 -c src/tsearch.c -o obj/tsearch.LINUX.32.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux32/include -D__HC_x86_32__ -DPOSIX -m32 -msse2 -c src/rp.c -o obj/rp.LINUX.32.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux32/include -D__HC_x86_32__ -DPOSIX -m32 -msse2 -c src/engine.c -o obj/engine.LINUX.32.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_x86_64__ -DPOSIX -m64 -msse2 -c src/tsearch.c -o obj/tsearch.LINUX.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_x86_64__ -DPOSIX -m64 -msse2 -c src/rp.c -o obj/rp.LINUX.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_x86_64__ -DPOSIX -m64 -msse2 -c src/engine.c -o obj/engine.LINUX.64.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_XOP__ -DWINDOWS -m64 -mxop -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/tsearch.c -o obj/tsearch.WIN.XOP.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_XOP__ -DWINDOWS -m64 -mxop -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/rp.c -o obj/rp.WIN.XOP.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_XOP__ -DWINDOWS -m64 -mxop -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/engine.c -o obj/engine.WIN.XOP.o
i686-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win32/include -D__HC_x86_32__ -DWINDOWS -m32 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/tsearch.c -o obj/tsearch.WIN.32.o
i686-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win32/include -D__HC_x86_32__ -DWINDOWS -m32 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/rp.c -o obj/rp.WIN.32.o
i686-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win32/include -D__HC_x86_32__ -DWINDOWS -m32 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/engine.c -o obj/engine.WIN.32.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_x86_64__ -DWINDOWS -m64 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/tsearch.c -o obj/tsearch.WIN.64.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_x86_64__ -DWINDOWS -m64 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/rp.c -o obj/rp.WIN.64.o
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_x86_64__ -DWINDOWS -m64 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign -c src/engine.c -o obj/engine.WIN.64.o
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_XOP__ -DPOSIX -m64 -mxop obj/*.LINUX.XOP.o src/hashcat-cli.c -o hashcat-cliXOP.bin  -Ldeps/gmp/linux64/lib -lm -lpthread -lgmp
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_XOP__ -DWINDOWS -m64 -mxop -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign obj/*.WIN.XOP.o /usr/x86_64-w64-mingw32/lib/CRT_glob.o src/hashcat-cli.c -o hashcat-cliXOP.exe  -Ldeps/gmp/win64/lib -lm -lgmp
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux64/include -D__HC_x86_64__ -DPOSIX -m64 -msse2 obj/*.LINUX.64.o src/hashcat-cli.c -o hashcat-cli64.bin  -Ldeps/gmp/linux64/lib -lm -lpthread -lgmp
gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/linux32/include -D__HC_x86_32__ -DPOSIX -m32 -msse2 obj/*.LINUX.32.o src/hashcat-cli.c -o hashcat-cli32.bin  -Ldeps/gmp/linux32/lib -lm -lpthread -lgmp
i686-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win32/include -D__HC_x86_32__ -DWINDOWS -m32 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign obj/*.WIN.32.o /usr/i686-w64-mingw32/lib/CRT_glob.o src/hashcat-cli.c -o hashcat-cli32.exe  -Ldeps/gmp/win32/lib -lm -lgmp
x86_64-w64-mingw32-gcc -W -Wall -pipe -I include/ -O2 -s -fomit-frame-pointer -funroll-loops -Ideps/gmp/win64/include -D__HC_x86_64__ -DWINDOWS -m64 -msse2 -D__USE_MINGW_ANSI_STDIO=1 -mstackrealign obj/*.WIN.64.o /usr/x86_64-w64-mingw32/lib/CRT_glob.o src/hashcat-cli.c -o hashcat-cli64.exe  -Ldeps/gmp/win64/lib -lm -lgmp
i686-apple-darwin10-gcc -W -Wall -pipe -I include/ -O2 -fomit-frame-pointer -funroll-loops -Ideps/gmp/osx64/include -D__HC_x86_64__ -DPOSIX -DOSX -m64 -msse2 -fnested-functions -arch x86_64 -mmacosx-version-min=10.5 obj/*.OSX.64.o src/hashcat-cli.c -o hashcat-cli64.app  -Ldeps/gmp/osx64/lib -lm -lpthread  -mmacosx-version-min=10.5 -lgmp
root@kali:~/hosthome/github/hashcat# ls 
build_linux.txt  docs               hashcat-cli32.exe  hashcat-cli64.exe   include      masks      rules  tables
charsets         examples           hashcat-cli64.app  hashcat-cliXOP.bin  Makefile     obj        salts  tools
deps             hashcat-cli32.bin  hashcat-cli64.bin  hashcat-cliXOP.exe  makelog.txt  README.md  src
root@kali:~/hosthome/github/hashcat# ./hashcat-cli32.bin --version
2.00
root@kali:~/hosthome/github/hashcat# ./hashcat-cli64.bin --version
2.00
root@kali:~/hosthome/github/hashcat# ./hashcat-cliXOP.bin --version
2.00
root@kali:~/hosthome/github/hashcat# uname -a
Linux kali 4.0.0-kali1-amd64 #1 SMP Debian 4.0.4-1+kali2 (2015-06-03) x86_64 GNU/Linux
```

Sorry if this seems to have become a bit over-engineered - I kept it out of the main build targets because its not that straightforward to 'cross-compile' for BSD, but I wanted something that would be easy for FreeBSD users which didn't break anything else.

Feel free to merge/close or just cut/paste into something else as you see fit :)
