### PR TITLE
add an .editorconfig file to enforce the indentation/code style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# top-most EditorConfig file, enforcing some of the code style
+#
+# See http://editorconfig.org for a plugin to your editor!
+#
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
I suggest that we add the .editorconfig file to this repository too ( it was recently added to oclHashcat, see https://github.com/hashcat/oclHashcat/pull/21 ).

To make it more consistent between hashcat and oclHashcat, we should add this file which seems to "helps a lot when working in projects with contradicting code styles. See http://editorconfig.org" (as magnum said on the pull request 21 of oclHashcat).

Thx
