### PR TITLE
minor: typo in BUILD.md (section about freebsd support)

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -31,6 +31,6 @@ $ make [linux|osx|windows|freebsd]
 
 Not specifying an argument will cross-compile binaries for Linux, Windows and OSX.
 
-If you native FreeBSD binaries, you will need **gmp** installed (/usr/ports/math/gmp). This has been tested on FreeBSD 10.2. 
+If you want to compile native FreeBSD binaries, you will need **gmp** installed (/usr/ports/math/gmp). This has been tested on FreeBSD 10.2. 
 
 Enjoy your fresh **Hashcat** binaries ;)


### PR DESCRIPTION
there was a typo in BUILD.md, should be fixed with this commit
