### PR TITLE
issue #30: crash in --benchmark

### DIFF
--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -15676,6 +15676,13 @@ int main (int argc, char *argv[])
     {
       if (file_hashes)
       {
+        if (benchmark == 1)
+        {
+          log_error ("Can not run benchmark against a hash file");
+
+          exit (-1);
+        }
+
         FILE *fp;
 
         if ((fp = fopen (file_hashes, "rb")) != NULL)


### PR DESCRIPTION
This fix should prevent users to use hash/dictionary files in benchmark mode.
