### PR TITLE
issue #2 related to pull request #33: fixes -s / -l problem with -a 0

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,11 @@ file.: Host
 desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
 issue: 10
 
+type.: bug
+file.: Host
+desc.: Fixed a problem with the -s / -l parameters in attack modes -a 0 (straight) and -a 3 (mask attack)
+issue: 2
+
 * changes v0.50 -> v2.00:
 
 type: Project

--- a/src/engine.c
+++ b/src/engine.c
@@ -16331,7 +16331,9 @@ void *attack_a0r0 (thread_parameter_t *thread_parameter)
 
     uint32_t i;
 
-    for (i = 0; i < 4; i++, words_next++)
+    uint limit = MIN (4, words_steps - words_cur);
+
+    for (i = 0; i < limit; i++, words_next++)
     {
       int next_len = words->words_len[words_next];
 
@@ -16344,6 +16346,11 @@ void *attack_a0r0 (thread_parameter_t *thread_parameter)
       plains[i].len = next_len;
 
       plains[i].pos = thread_parameter->thread_words_done + i;
+    }
+
+    for (; i < 4; i++)
+    {
+      plains[i].len = 0;
     }
 
     thread_parameter->hashing (thread_parameter, plains);


### PR DESCRIPTION
This fix is similar to the fix from pull request #33 . While the other push did only fix attack mode 3 (mask attack), this one does also fix -a 0.

I did test all 7 supported attack modes for similar problems and indeed I found some further related bugs that will be reported with new issues and hopefully fixed with some pull requests.
Thx
