### PR TITLE
fix for issue #36: problem with permutation attack (-a 4)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,11 @@ file.: Host
 desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
 issue: 10
 
+type.: bug
+file.: Host
+desc.: Fixed the output of attack mode -a 4 (permutation attack)
+issue: 36
+
 * changes v0.50 -> v2.00:
 
 type: Project

--- a/src/engine.c
+++ b/src/engine.c
@@ -15647,7 +15647,7 @@ void *attack_a4r0 (thread_parameter_t *thread_parameter)
 
     for (k = 0; k < words->words_len[words_next] + 1; k++) p[k] = k;
 
-    k = 1;
+    k = 0;
 
     /* main loop */
 
@@ -15657,16 +15657,18 @@ void *attack_a4r0 (thread_parameter_t *thread_parameter)
     {
       for (i = 0; i < 4; i++)
       {
-        if ((k = next_permutation (words->words_buf[words_next], p, k)) == words->words_len[words_next]) break;
+        k = next_permutation (words->words_buf[words_next], p, k);
 
         memcpy (ptrs[i], words->words_buf[words_next], words->words_len[words_next]);
 
         plains[i].pos = thread_parameter->thread_plains_done + i;  // TODO: needs verification
+
+        if (k == words->words_len[words_next]) break;
       }
 
       int j;
 
-      for (j = i; j < 4; j++)
+      for (j = i + 1; j < 4; j++) // the +1 is here because if < 4, we did use 'break' to exit the loop
       {
         memset (ptrs[j], 0, BLOCK_SIZE);
 


### PR DESCRIPTION
There was a problem that I described with issue #36 where hashcat did not generate all possibilities in attack mode -a 4 (permutation attack).

This fix should fix this problem and furthermore I did some intensive tests with -s / -l parameters which seems to working together perfectly now.
A possible test to double-check is https://hashcat.net/wiki/doku.php?id=permutation_attack (the resulting lines need to be the same as in the example, including the number of outputted lines, while the "sorting" of the generated lines is not important).
Thx
