### PR TITLE
fix for issue #37: clear buffers when approaching the final set of password candidates

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,11 @@ file.: Host
 desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
 issue: 10
 
+type.: bug
+file.: Host
+desc.: Implemented a fix for the final output for attack mode -a 5 (table lookup attack)
+issue: 37
+
 * changes v0.50 -> v2.00:
 
 type: Project

--- a/src/engine.c
+++ b/src/engine.c
@@ -15554,6 +15554,13 @@ void *attack_a5r0 (thread_parameter_t *thread_parameter)
         memset (ptrs[j] + plains[j].len, 0, BLOCK_SIZE - plains[j].len);
       }
 
+      for (; j < 4; j++)
+      {
+        memset (ptrs[j], 0, BLOCK_SIZE);
+
+        plains[j].len = 0;
+      }
+
       thread_parameter->hashing (thread_parameter, plains);
 
       thread_parameter->thread_plains_done += left;


### PR DESCRIPTION
The problem as described with issue #37 was that the final set of lines outputted by the -a 5 (table lookup attack) seemed to be garbage and not meaningful at all.
It seemed that there were some left-over buffers which were not cleared correctly.

This suspicion was confirmed and reproduced easily and also the fix/patch is as easy as you can see below (just unset/reset the buffers if they are not needed anymore).
Thx
