### PR TITLE
for issue #40: Prince didn't use -s / -l correctly

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,11 @@ file.: Host
 desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
 issue: 10
 
+type.: bug
+file.: Host
+desc.: Fixed the use of -s / -l parameters together with the attack mode -a 8 (Prince)
+issue: 40
+
 * changes v0.50 -> v2.00:
 
 type: Project

--- a/src/hashcat-cli.c
+++ b/src/hashcat-cli.c
@@ -16461,6 +16461,13 @@ int main (int argc, char *argv[])
     }
     else if (attack_mode == 8)
     {
+      /* hack: since run_threads () and hashing_xxxxx () will use these engine_parameter->words_skip and engine_parameter->words_limit
+       * values, we need to make sure that we don't skip and limit twice, therefore we set them to 0 here, because the below PRINCE algo
+       * already does the skipping/limiting
+       */
+      engine_parameter->words_skip  = 0;
+      engine_parameter->words_limit = 0;
+
       mpz_t pw_ks_pos[OUT_LEN_MAX + 1];
       mpz_t pw_ks_cnt[OUT_LEN_MAX + 1];
 
@@ -17070,6 +17077,11 @@ int main (int argc, char *argv[])
       free (wordlen_dist);
       free (pw_orders);
       free (db_entries);
+
+      // don't forget to reset the skip and limit values
+
+      engine_parameter->words_skip  = words_skip;
+      engine_parameter->words_limit = words_limit;
     }
 
     /*


### PR DESCRIPTION
This fix should fix issue #40. hashcat in attack mode -a 8 (Prince) did not use the -s / -l values correctly.
This should be fixed with this patch, which forces the run_threads () and therefore the hashing_xxxxx () functions to not skip/limit again since Prince did this task already.
Thx
