### PR TITLE
minor: docs/changes.txt problem (bug vs feature)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -5,15 +5,15 @@ file.: Host
 desc.: Added native compilation support for FreeBSD
 PR...: 23, 25
 
-type.: Feature
-file.: Host
-desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
-issue: 10
-
 type.: Bug
 file.: Host
 desc.: Fixed a problem with the -s / -l parameters in attack modes -a 0 (straight) and -a 3 (mask attack)
 issue: 2
+
+type.: Bug
+file.: Host
+desc.: Fixed a possible memory problem for hash type -m 11400 = SIP digest authentication (MD5)
+issue: 10
 
 type.: Bug
 file.: Host


### PR DESCRIPTION
There was a problem in docs/changes.txt were a bug was wrongly classified as a feature.
Thix patch should fix this documentation problem.
Thx
