### PR TITLE
issue #54: fixed memory issue with some unicode algorithms

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -37,6 +37,11 @@ issue: 40
 
 type.: Bug
 file.: Host
+desc.: Fixed a memory issue with algorithms using unicode when trying password candidates longer than 27 characters
+issue: 54
+
+type.: Bug
+file.: Host
 desc.: Fixed --help text for hash type -m 9900 = Radmin2 (was wronly displayed as -m 9800 = Radmin2)
 
 * changes v0.50 -> v2.00:

--- a/src/engine.c
+++ b/src/engine.c
@@ -4599,6 +4599,8 @@ void md4_final_sse2_max55 (plain_t *plains, digest_md4_sse2_t *digests)
   {
     plain_t *ptr = plains + i;
 
+    if (ptr.len >= 56) continue;
+
     memset (ptr->buf8 + ptr->len, 0, 64 - ptr->len);
 
     ptr->buf8[ptr->len] = 0x80;
@@ -4617,6 +4619,8 @@ void md5_final_sse2_max55 (plain_t *plains, digest_md5_sse2_t *digests)
   {
     plain_t *ptr = plains + i;
 
+    if (ptr->len >= 56) continue;
+
     memset (ptr->buf8 + ptr->len, 0, 64 - ptr->len);
 
     ptr->buf8[ptr->len] = 0x80;
@@ -4634,6 +4638,8 @@ void sha1_final_sse2_max55 (plain_t *plains, digest_sha1_sse2_t *digests)
   for (i = 0; i < 4; i++)
   {
     plain_t *ptr = plains + i;
+
+    if (ptr->len >= 56) continue;
 
     memset (ptr->buf8 + ptr->len, 0, 64 - ptr->len);
 
@@ -4654,6 +4660,8 @@ void sha256_final_sse2_max55 (plain_t *plains, digest_sha256_sse2_t *digests)
   for (i = 0; i < 4; i++)
   {
     plain_t *ptr = plains + i;
+
+    if (ptr->len >= 56) continue;
 
     memset (ptr->buf8 + ptr->len, 0, 64 - ptr->len);
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -4599,7 +4599,7 @@ void md4_final_sse2_max55 (plain_t *plains, digest_md4_sse2_t *digests)
   {
     plain_t *ptr = plains + i;
 
-    if (ptr.len >= 56) continue;
+    if (ptr->len >= 56) continue;
 
     memset (ptr->buf8 + ptr->len, 0, 64 - ptr->len);
 


### PR DESCRIPTION
The problem was originally reported (#54) for -m 133 = PeopleSoft, but this problem could affect other algorithms too.
The main issue is that with algorithms using unicode the final password length will double, so we currently support "only" 55 / 2 = 27 characters. Some checks within the *_final_sse2_max55 () functions were missing and therefore there was the possibility that the memory could get corrupted.

This pull request adds further checks.

Thx

(btw: I was able to reproduce and with this fix the crash does not occur anymore: should be fixed!)
