### PR TITLE
Fix "memory" issue in rule processor

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -594,7 +594,7 @@ int apply_rule (char *rule, int rule_len, char in[BLOCK_SIZE], int in_len, char 
   if (rule_len < 1) return (RULE_RC_REJECT_ERROR);
 
   int out_len = in_len;
-  int mem_len = in_len;
+  int mem_len = 0;
 
   memcpy (out, in, out_len);
 


### PR DESCRIPTION
The `mem` structure contains uninitialized data so it's length should be considered zero (until updated by `RULE_OP_MEMORIZE_WORD`).
Setting `mem_len = in_len` allows accessing up to `in_len` bytes of uninitialized memory.

Alternate fix: `memcpy(mem, in, mem_len);`
