### PR TITLE
Updated libssl0.9.8_0.9.8o-4squeeze14_amd64.deb link.

### DIFF
--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -37,7 +37,7 @@ cd apple-pkgs
 dpkg -l | grep libssl0.9.8 | grep ^ii &>/dev/null
 if [ $? -ne 0 ]; then
   if [ ! -f "libssl0.9.8_0.9.8o-4squeeze14_amd64.deb" ]; then
-    wget -c http://http.us.debian.org/debian/pool/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
+    wget -c http://security.debian.org/pool/updates/main/o/openssl/libssl0.9.8_0.9.8o-4squeeze14_amd64.deb
     if [ $? -ne 0 ]; then
       echo "! failed to download libssl0.9.8 debian package"
       exit 1


### PR DESCRIPTION
The old libssl0.9.8_0.9.8o-4squeeze14_amd64.deb points to a 404 page.  Updated to a new working link from security.debian.org.
