### PR TITLE
Update BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -13,7 +13,7 @@ To compile **Hashcat** you need to cross compile the **gmp** library for Linux (
 First get a copy of **Hashcat** repository
 
 ```sh
-$ git clone https://github.com/hashcat/hashcat.git
+$ git clone https://github.com/hashcat/hashcat-legacy.git
 ```
 
 Install the dependencies


### PR DESCRIPTION
The `git clone` link is incorrect. It downloads the _mainstream_ **hashcat** repository instead of the its _legacy_ counterpart.